### PR TITLE
$null要素の比較が正しく評価されない問題があるため修正

### DIFF
--- a/scripts/windows/floppy_files/win-updates.ps1
+++ b/scripts/windows/floppy_files/win-updates.ps1
@@ -63,7 +63,7 @@ function Install-WindowsUpdates() {
     $CurrentUpdates = $SearchResult.Updates
     while($script:i -lt $CurrentUpdates.Count -and $script:CycleUpdateCount -lt $MaxUpdatesPerCycle) {
         $Update = $CurrentUpdates.Item($script:i)
-        if (($Update -ne $null) -and (!$Update.IsDownloaded)) {
+        if (($null -ne $Update) -and (!$Update.IsDownloaded)) {
             [bool]$addThisUpdate = $false
             if ($Update.InstallationBehavior.CanRequestUserInput) {
                 LogWrite "> Skipping: $($Update.Title) because it requires user input"


### PR DESCRIPTION
$null要素の比較は演算子の左側に無い場合、正しく評価されない可能性があるので修正しました。